### PR TITLE
patch to fix linker issues on Ubuntu build farm from cjwatson.

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ multiarch.patch
 python.patch
 examples.patch
 test.patch
+ubuntu-linker-fix.patch

--- a/debian/patches/ubuntu-linker-fix.patch
+++ b/debian/patches/ubuntu-linker-fix.patch
@@ -1,0 +1,34 @@
+Description: Link libAria.so directly with the libraries it uses
+Author: Colin Watson <cjwatson@ubuntu.com>
+Bug-Debian: http://bugs.debian.org/726429
+Forwarded: no
+Last-Update: 2013-10-22
+
+Index: b/Makefile
+===================================================================
+--- a/Makefile
++++ b/Makefile
+@@ -34,12 +34,12 @@
+   $(info Building on MinGW)
+ 	#CXXFLAGS+=-mwindows -mms-bitfields -D__MINGW__ -DMINGW
+ 	CXXFLAGS+=-mms-bitfields -D__MINGW__ -DMINGW
+-	CXXLINK+=-lpthreadGC2 -lwinmm -lws2_32 -lstdc++
++	LIBARIA_LDADD=-lpthreadGC2 -lwinmm -lws2_32 -lstdc++
+ 	CXXSTATICLINK+=-Wl,-Bstatic -lpthread -Wl,-Bdynamic -lwinmm -lws2_32 -lstdc++
+ 	binsuffix:=.exe
+ else
+ 	BARECXXFLAGS+=-fPIC
+-	CXXLINK+=-lpthread -ldl -lrt
++	LIBARIA_LDADD=-lpthread -ldl -lrt
+ 	CXXSTATICLINK+=-Xlinker -Bdynamic -lpthread -ldl -lrt -Xlinker -Bstatic -lstdc++ -Xlinker -Bdynamic
+ 	binsuffix:=
+ endif
+@@ -600,7 +600,7 @@
+ ####
+ 
+ lib/libAria.so: $(OFILES) Makefile.dep 
+-	$(CXX) -shared -Wl,-soname,libAria.so.2 $(LDFLAGS) -o $(@).2.8.0 $(OFILES)
++	$(CXX) -shared -Wl,-soname,libAria.so.2 $(LDFLAGS) -o $(@).2.8.0 $(OFILES) $(LIBARIA_LDADD)
+ 	ln -s libAria.so.2.8.0 lib/libAria.so.2
+ 	ln -s libAria.so.2 lib/libAria.so
+ 


### PR DESCRIPTION
Patch from cjwatson, fixes compilation on the ubuntu build farm:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726429

I have no idea how to build this repository, so I'm afraid I can't properly test it but it is currently in use by the downstream Ubuntu repo's deb files so I'm guessing it's alright.
